### PR TITLE
Initial version of Mac OS CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,25 @@
+name: macOS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  xcode:
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        xcode: [12.4, 12.3, 12.2, 12.1.1, 12.1, 12, 11.7, 11.6, 11.5, 11.4.1, 11.3.1, 11.2.1]
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: cmake
+        run: cmake -S . -B build -D CMAKE_BUILD_TYPE=Debug
+      - name: build
+        run: cmake --build build --parallel 10
+      - name: test
+        run: cd build && ctest -j 10 --output-on-failure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        compiler: [g++-5, g++-6, g++-7, g++-8, g++-9, g++-10, clang++-10]
+        compiler: [g++-5, g++-6, g++-7, g++-8, g++-9, g++-10, clang++-6.0, clang++-10]
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Ubuntu](https://github.com/AmadeusITGroup/amc/actions/workflows/ubuntu.yml/badge.svg)](https://github.com/AmadeusITGroup/amc/actions/workflows/ubuntu.yml)
 [![Windows](https://github.com/AmadeusITGroup/amc/actions/workflows/windows.yml/badge.svg)](https://github.com/AmadeusITGroup/amc/actions/workflows/windows.yml)
+[![MacOS](https://github.com/AmadeusITGroup/amc/actions/workflows/macos.yml/badge.svg)](https://github.com/AmadeusITGroup/amc/actions/workflows/macos.yml)
 
 # AMadeus (C++) Containers
 
@@ -107,5 +108,5 @@ To compile and launch the tests in `Debug` mode, simply launch
 
 This library has been tested on Ubuntu 18.04 and Windows 10 (Visual Studio 2019), cmake 3.19.4 and the following compilers:
  - GCC from version 5.5 to 10
- - Clang from version 10 (earlier versions of Clang fail to compile the [C++ member detector idiom](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector))
+ - Clang from version 6.0
  - MSVC 19.28

--- a/src/include/amc_isdetected.hpp
+++ b/src/include/amc_isdetected.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <type_traits>
+
+#include "amc_config.hpp"
+
+/// Emulation of std::experimental::is_detected feature.
+/// Sources:
+///    https://people.eecs.berkeley.edu/~brock/blog/detection_idiom.php
+///       - Excellent blog page explaining the evolution of C++ detection idiom implementations)
+///    https://en.cppreference.com/w/cpp/experimental/is_detected
+///       - Code taken from above page
+namespace amc {
+
+#ifdef AMC_CXX17
+using std::void_t;
+#else
+template <class...>
+using void_t = void;
+#endif
+
+namespace detail {
+template <class Default, class AlwaysVoid, template <class...> class Op, class... Args>
+struct detector {
+  using value_t = std::false_type;
+  using type = Default;
+};
+
+template <class Default, template <class...> class Op, class... Args>
+struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
+  using value_t = std::true_type;
+  using type = Op<Args...>;
+};
+
+}  // namespace detail
+
+struct nonesuch {
+  ~nonesuch() = delete;
+  nonesuch(nonesuch const&) = delete;
+  void operator=(nonesuch const&) = delete;
+};
+
+template <template <class...> class Op, class... Args>
+using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
+
+template <template <class...> class Op, class... Args>
+using detected_t = typename detail::detector<nonesuch, void, Op, Args...>::type;
+
+template <class Default, template <class...> class Op, class... Args>
+using detected_or = detail::detector<Default, void, Op, Args...>;
+
+template <class T>
+using copy_assign_t = decltype(std::declval<T&>() = std::declval<const T&>());
+
+template <class Expected, template <class...> class Op, class... Args>
+using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
+
+template <class Default, template <class...> class Op, class... Args>
+using detected_or_t = typename detected_or<Default, Op, Args...>::type;
+}  // namespace amc

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -30,6 +30,11 @@ function(add_unit_test name)
 endfunction()
 
 add_unit_test(
+  amc_isdetected_test
+  amc_isdetected_test.cpp
+)
+
+add_unit_test(
   vectors_test
   vectors_test.cpp
 )

--- a/src/test/amc_isdetected_test.cpp
+++ b/src/test/amc_isdetected_test.cpp
@@ -1,0 +1,34 @@
+#include "amc_isdetected.hpp"
+
+#include "amc_allocator.hpp"
+#include "amc_smallvector.hpp"
+
+namespace amc {
+static_assert(vec::has_reallocate<amc::allocator<int>>::value, "amc::allocator should provide reallocate method");
+static_assert(!vec::has_reallocate<std::allocator<int>>::value, "std::allocator does not provide reallocate method");
+
+struct Meow {
+  using pointer = const char *;
+  using size_type = int;
+
+  pointer reallocate(pointer);
+  pointer reallocate(pointer, size_type);
+  pointer reallocate(pointer, size_type, size_type);
+};
+
+struct Purr {
+  using pointer = const char *;
+  using size_type = int;
+
+  Purr &operator=(const Purr &) = delete;
+
+  pointer reallocate(pointer, size_type, size_type, size_type);
+};
+
+static_assert(is_detected<copy_assign_t, Meow>::value, "Meow should be copy assignable!");
+static_assert(!is_detected<copy_assign_t, Purr>::value, "Purr should not be copy assignable!");
+static_assert(is_detected_exact<Meow &, copy_assign_t, Meow>::value, "Copy assignment of Meow should return Meow&!");
+
+static_assert(!vec::has_reallocate<Meow>::value, "Meow should not provide reallocate method");
+static_assert(vec::has_reallocate<Purr>::value, "Purr should provide reallocate method");
+}  // namespace amc


### PR DESCRIPTION
AppleClang fails to compile the C++ member detector included in the library (taken from https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Member_Detector)