### PR TITLE
Check allocator type and value type match in sets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,8 @@ if(MAIN_PROJECT)
   endif(MSVC)
 endif(MAIN_PROJECT)
 
-if(AMC_ENABLE_ASAN)
-  if(NOT MSVC)
-    add_compile_options(-g -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover=all)
-  endif()
+if(AMC_ENABLE_ASAN AND NOT MSVC)
+  add_compile_options(-g -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize-recover=all)
 endif()
 
 # Create interface library for header files

--- a/src/benchmark/sets_benchmark.cpp
+++ b/src/benchmark/sets_benchmark.cpp
@@ -10,7 +10,7 @@
 #include "testhelpers.hpp"
 #include "testtypes.hpp"
 
-#ifdef AMC_CXX17
+#ifdef AMC_SMALLSET
 #include "amc_smallset.hpp"
 #endif
 
@@ -149,7 +149,7 @@ BENCHMARK_TEMPLATE(LookUp, REFInt, 100000);
 BENCHMARK_TEMPLATE(LookUp, REFUnoInt, 100000);
 BENCHMARK_TEMPLATE(LookUp, AMCInt, 100000);
 
-#ifdef AMC_CXX17
+#ifdef AMC_SMALLSET
 BENCHMARK_TEMPLATE(CommonUsage, amc::SmallSet<uint32_t, 50>, 50);
 BENCHMARK_TEMPLATE(CommonUsage, std::unordered_set<uint32_t>, 50);
 #endif

--- a/src/include/amc_config.hpp
+++ b/src/include/amc_config.hpp
@@ -40,6 +40,7 @@
 
 #if _MSVC_LANG >= 201703L
 #define AMC_CXX17 1
+#define AMC_SMALLSET 1
 #endif
 
 #define AMC_CXX14 1
@@ -51,6 +52,7 @@
 
 #if __cplusplus >= 201703L
 #define AMC_CXX17 1
+#define AMC_SMALLSET 1
 #endif
 
 #if __cplusplus > 201703L

--- a/src/include/amc_smallset.hpp
+++ b/src/include/amc_smallset.hpp
@@ -123,6 +123,9 @@ class SmallSet {
 
   static_assert(N <= 64, "N should be small as search has linear complexity for small sets");
 
+  static_assert(std::is_same<T, typename SetType::value_type>::value, "Set value type should be T");
+  static_assert(std::is_same<Alloc, typename SetType::allocator_type>::value, "Allocator should match set's");
+
  public:
   using key_type = T;
   using value_type = T;
@@ -471,11 +474,12 @@ class SmallSet {
       bool operator()(const_pointer pLhs, const_reference rhs) const { return *pLhs < rhs; }
       bool operator()(const_reference lhs, const_pointer pRhs) const { return lhs < *pRhs; }
     };
+
     if (isSmall()) {
-      PtrVec sortedPtrs = ComputeSortedPtrVec(_vec);
+      auto sortedPtrs = ComputeSortedPtrVec(_vec);
       if (o.isSmall()) {
         // We are both small, we need to sort both containers
-        PtrVec oSortedPtrs = ComputeSortedPtrVec(o._vec);
+        auto oSortedPtrs = ComputeSortedPtrVec(o._vec);
         return std::lexicographical_compare(sortedPtrs.begin(), sortedPtrs.end(), oSortedPtrs.begin(),
                                             oSortedPtrs.end(), LessPtrFunc());
       }
@@ -485,12 +489,13 @@ class SmallSet {
     }
     if (o.isSmall()) {
       // other is small: as we do not order elements in the small container, we need to sort them.
-      PtrVec oSortedPtrs = ComputeSortedPtrVec(o._vec);
+      auto oSortedPtrs = ComputeSortedPtrVec(o._vec);
       return std::lexicographical_compare(_set.begin(), _set.end(), oSortedPtrs.begin(), oSortedPtrs.end(),
                                           LessPtrFunc());
     }
     return _set < o._set;
   }
+
   bool operator<=(const SmallSet &o) const { return !(o < *this); }
   bool operator>(const SmallSet &o) const { return o < *this; }
   bool operator>=(const SmallSet &o) const { return !(*this < o); }
@@ -528,7 +533,9 @@ class SmallSet {
 
   struct FindFunctor {
     FindFunctor(Compare comp, const_reference v) : _comp(comp), _v(v) {}
+
     bool operator()(const_reference o) const { return !_comp(_v, o) && !_comp(o, _v); }
+
     Compare _comp;
     const_reference _v;
   };

--- a/src/include/amc_vectorcommon.hpp
+++ b/src/include/amc_vectorcommon.hpp
@@ -1412,6 +1412,8 @@ class Vector : public vec::VectorWithInplaceStorage<T, Alloc, SizeType, GrowingP
   using const_reference = typename Base::const_reference;
   using size_type = SizeType;
 
+  static constexpr size_type kInlineCapacity = N;
+
   Vector() noexcept : Base(N) {}
 
   explicit Vector(const Alloc &alloc) noexcept : Base(N, alloc) {}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -27,7 +27,7 @@ function(add_unit_test name)
    set_tests_properties(${name} PROPERTIES
                         ENVIRONMENT "UBSAN_OPTIONS=halt_on_error=1 abort_on_error=1 print_stacktrace=1; LSAN_OPTIONS=detect_leaks=1 malloc_context_size=2 print_suppressions=0"
                         WORKING_DIRECTORY ${CMAKE_HOME_DIRECTORY})
-   if (AMC_ENABLE_ASAN)
+   if (AMC_ENABLE_ASAN AND NOT MSVC)
      target_link_options(${name} PRIVATE -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero)
    endif()
 endfunction()


### PR DESCRIPTION
Addition of some useful `static_assert`s with `allocator_type` and `value_type` checks.
Also separate `SmallSet` and `C++17` definitions although there are linked.

Add more set types in the unit test as `FlatSet` and `SmallSet` are heavily templated.