### PR TITLE
Addition of pointer based methods to FlatSet

### DIFF
--- a/src/include/amc_flatset.hpp
+++ b/src/include/amc_flatset.hpp
@@ -164,6 +164,12 @@ class FlatSet : private Compare {
   const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(cend()); }
   const_reverse_iterator crend() const noexcept { return const_reverse_iterator(cbegin()); }
 
+  const_pointer data() const noexcept { return _sortedVector.data(); }
+
+  const_reference operator[](size_type idx) const { return _sortedVector[idx]; }
+
+  const_reference at(size_type idx) const { return _sortedVector.at(idx); }
+
   bool empty() const noexcept { return _sortedVector.empty(); }
   size_type size() const noexcept { return _sortedVector.size(); }
   size_type max_size() const noexcept { return _sortedVector.max_size(); }

--- a/src/test/sets_test.cpp
+++ b/src/test/sets_test.cpp
@@ -456,6 +456,16 @@ TEST(FlatSetTest, MergeDifferentCompare) {
   EXPECT_EQ(s2, RevSetType({19, 4, 2, -2}));
 }
 
+TEST(FlatSetTest, SpecificPointerMethods) {
+  using SetType = FlatSet<int>;
+  SetType s{-2, 0, 2, 3, 4, 6, 19};
+  const SetType::value_type* pValue = s.data();  // to ensure return type of data() is a pointer
+  EXPECT_EQ(pValue[0], -2);
+  EXPECT_EQ(s[1], 0);
+  EXPECT_EQ(s.at(2), 2);
+  EXPECT_THROW(s.at(7), std::out_of_range);
+}
+
 #ifdef AMC_SMALLSET
 TEST(SmallSetTest, MergeDifferentCompare) {
   using SetType = SmallSet<char, 20, std::less<char>>;


### PR DESCRIPTION
It makes sense to propose pointer based (`data()`, `operator[]` and `at()`) methods for `FlatSet` as it guarantees contiguous memory.