### PR TITLE
Make amc::vector declaration work with incomplete types like std::vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.14)
-project(amc VERSION 1.1
+project(amc VERSION 1.2
             DESCRIPTION "Header base library of C++ containers"
             LANGUAGES CXX)
 

--- a/src/test/vectors_test.cpp
+++ b/src/test/vectors_test.cpp
@@ -197,8 +197,8 @@ typedef ::testing::Types<
 // clang-format on
 TYPED_TEST_SUITE(VectorRefTest, MyTypesForRef, );
 
-template <class T, class A, class S, bool I, class G>
-inline bool operator==(const VectorImpl<T, A, S, I, G> &lhs, const typename std::vector<T> &rhs) {
+template <class T, class A, class S, class G, S N>
+inline bool operator==(const Vector<T, A, S, G, N> &lhs, const typename std::vector<T> &rhs) {
   return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
@@ -508,5 +508,21 @@ TEST(VectorTest, SmallVectorOptimizedSizeInt) {
   ints.push_back(7567);
   EXPECT_EQ(ints, SmallInt16SmallVector({42, -56, -56, 42, 42, 37, 7567}));
 }
+
+#if defined(AMC_CXX20) || (!defined(_MSC_VER) && defined(AMC_CXX17))
+// Some earlier compilers may not be able to compile this
+// Indeed, it is only specified from C++17 that std::vector may compile with incomplete types
+// More information here: https://en.cppreference.com/w/cpp/container/vector
+// For some reason, MSVC 2017 is not able to compile this, even with CXX17 enabled. Activate only in CXX20 for MSVC
+TEST(VectorTest, IncompleteType) {
+  struct Foo {
+    amc::vector<Foo> v;
+  };
+
+  Foo f;
+  EXPECT_TRUE(f.v.empty());
+}
+
+#endif
 
 }  // namespace amc


### PR DESCRIPTION
At instantiation of `amc::vector` with an incomplete type, there was a compiler error as we try to access to `sizeof(T)` and `std::is_trivially_destructible<T>`, unlike `std::vector` which works fine (and is defined standard behavior from C++17).

This PR makes it possible to use `amc::vector` with incomplete types.