### PR TITLE
Fix unaligned access and simplify code

### DIFF
--- a/src/test/testtypes.hpp
+++ b/src/test/testtypes.hpp
@@ -273,28 +273,35 @@ struct MoveForbidden {
       typename std::conditional<IsTriviallyRelocatable, std::true_type, std::false_type>::type;
 };
 
-struct UnalignedToPtr1 {
-  UnalignedToPtr1(uint32_t i) { std::memcpy(c, std::addressof(i), sizeof(uint32_t)); }
+template <unsigned int Size>
+struct UnalignedToPtr {
+  static constexpr size_t kIntSize = Size < sizeof(uint32_t) ? Size : sizeof(uint32_t);
+
+  UnalignedToPtr(uint32_t i) { std::memcpy(c, &i, kIntSize); }
 
   operator uint32_t() const {
-    uint32_t ret;
-    std::memcpy(std::addressof(ret), c, sizeof(uint32_t));
+    uint32_t ret{};
+    std::memcpy(&ret, c, kIntSize);
     return ret;
   }
 
-  char c[5];
+  char c[Size];
 };
 
+template <unsigned int Size, class T>
 struct UnalignedToPtr2 {
-  UnalignedToPtr2(uint32_t i) { std::memcpy(c, std::addressof(i), 3); }
+  static constexpr size_t kIntSize = Size < sizeof(uint32_t) ? Size : sizeof(uint32_t);
+
+  UnalignedToPtr2(uint32_t i) { std::memcpy(c, &i, kIntSize); }
 
   operator uint32_t() const {
-    uint32_t ret = 0;
-    std::memcpy(std::addressof(ret), c, 3);
+    uint32_t ret{};
+    std::memcpy(&ret, c, kIntSize);
     return ret;
   }
 
-  char c[3];
+  T e;
+  char c[Size];
 };
 
 class TestAllocator {


### PR DESCRIPTION
Fix unaligned access occurring when using vector of SmallVector of a special type:
```
[ctest] /home/sjanel/perso/amc/src/test/../include/amc_vectorcommon.hpp:400:96: runtime error: load of misaligned address 0x613000017264 for type 'struct UnalignedToPtr *', which requires 8 byte alignment
[ctest] 0x613000017264: note: pointer points here
[ctest]   00 00 00 00 90 3e 68 00  40 60 00 00 be be be be  be be be be be be be be  be be be be be be be be
[ctest]               ^ 
[ctest]     #0 0x562ec3f78705 in amc::vec::ElemWithPtrStorageImpl<amc::UnalignedToPtr<7u>, false>::dyn() const (/home/sjanel/perso/amc/build/src/test/vectors_test+0xac3705)
```
The specialization of `ElemWithPtrStorageImpl` is just not needed actually.