### PR TITLE
Make code compatible with C++20

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -93,13 +93,17 @@ jobs:
         run: cd build && ctest -j 2 --output-on-failure
 
   ci_test_standards:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         standard: [11, 14, 17, 20]
-        compiler: [g++, clang++]
+        compiler: [g++-11, clang++-14]
     steps:
       - uses: actions/checkout@v2
+      - name: Install compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.compiler }}
       - name: cmake
         run: cmake -S . -B build -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_CXX_STANDARD=${{ matrix.standard }} -DCMAKE_BUILD_TYPE=Debug
       - name: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required (VERSION 3.14)
 
 project(amc 
-  VERSION 2.4.0
+  VERSION 2.5.0
   DESCRIPTION "Header base library of C++ containers"
   LANGUAGES CXX
 )
 
 # This library needs C++11, except for SmallSet which requires std::variant from C++17.
 # Emulations of newer C++ functions is provided for non C++14 / C++17 compilers.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard")
+set(CMAKE_CXX_EXTENSIONS OFF CACHE STRING "Deactivate C++ extensions for maximum portability")
 
 ##
 ## MAIN_PROJECT CHECK

--- a/test/amc_isdetected_test.cpp
+++ b/test/amc_isdetected_test.cpp
@@ -34,7 +34,9 @@ static_assert(!vec::has_reallocate<Meow>::value, "Meow should not provide reallo
 static_assert(vec::has_reallocate<Purr>::value, "Purr should provide reallocate method");
 
 static_assert(has_is_transparent<Meow>::value, "Meow should have is_transparent type");
+#ifdef AMC_CXX14
 static_assert(has_is_transparent<std::less<>>::value, "std::less<> should have is_transparent type");
+#endif
 static_assert(!has_is_transparent<std::less<int>>::value, "std::less<T> should not have is_transparent type");
 static_assert(!has_is_transparent<Purr>::value, "Purr should not have is_transparent type");
 }  // namespace amc


### PR DESCRIPTION
Makes `amc` compile with C++20 standard. Changes:
 - Add default constructor to `SmallSet` iterator (to comply with ranges concepts)
 - Cannot take address of `std::addressof` utility function anymore (replace with simple lambda)